### PR TITLE
Adding the search bar ui to topics bar

### DIFF
--- a/templates/partials/topic-list-bar.tpl
+++ b/templates/partials/topic-list-bar.tpl
@@ -36,6 +36,11 @@
 			</div>
 
 			<div class="d-flex gap-1 align-items-center">
+				<!-- Search Bar with Button -->
+				<div class="input-group flex-nowrap w-auto">
+					<input type="text" class="form-control form-control-sm w-auto" placeholder="[[global:search]]">
+					<span class="input-group-text px-2 search-button"><i class="fa fa-search"></i></span>
+				</div>
 				{{{ if template.category }}}
 					{{{ if privileges.topics:create }}}
 					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
@@ -50,11 +55,7 @@
 				<a component="category/post/guest" href="{config.relative_path}/login" class="btn btn-sm btn-primary">[[category:guest-login-post]]</a>
 				{{{ end }}}
 				<br>
-				<!-- Search Bar with Button -->
-				<div class="input-group flex-nowrap w-auto">
-					<input type="text" class="form-control form-control-sm w-auto" placeholder="[[global:search]]">
-					<span class="input-group-text px-2 search-button"><i class="fa fa-search"></i></span>
-				</div>
+
 			</div>
 		</div>
 	</nav>

--- a/templates/partials/topic-list-bar.tpl
+++ b/templates/partials/topic-list-bar.tpl
@@ -36,7 +36,7 @@
 			</div>
 
 			<div class="d-flex gap-1 align-items-center">
-				<!-- My changes -->
+				<!-- Search Bar with Button -->
 				<div class="input-group flex-nowrap w-auto">
 					<input type="text" class="form-control form-control-sm w-auto" placeholder="[[global:search]]">
 					<span class="input-group-text px-2 search-button"><i class="fa fa-search"></i></span>

--- a/templates/partials/topic-list-bar.tpl
+++ b/templates/partials/topic-list-bar.tpl
@@ -36,12 +36,6 @@
 			</div>
 
 			<div class="d-flex gap-1 align-items-center">
-				<!-- Search Bar with Button -->
-				<div class="input-group flex-nowrap w-auto">
-					<input type="text" class="form-control form-control-sm w-auto" placeholder="[[global:search]]">
-					<span class="input-group-text px-2 search-button"><i class="fa fa-search"></i></span>
-				</div>
-				<br>
 				{{{ if template.category }}}
 					{{{ if privileges.topics:create }}}
 					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
@@ -55,6 +49,12 @@
 				{{{ if (!loggedIn && (!privileges.topics:create && !canPost))}}}
 				<a component="category/post/guest" href="{config.relative_path}/login" class="btn btn-sm btn-primary">[[category:guest-login-post]]</a>
 				{{{ end }}}
+				<br>
+				<!-- Search Bar with Button -->
+				<div class="input-group flex-nowrap w-auto">
+					<input type="text" class="form-control form-control-sm w-auto" placeholder="[[global:search]]">
+					<span class="input-group-text px-2 search-button"><i class="fa fa-search"></i></span>
+				</div>
 			</div>
 		</div>
 	</nav>


### PR DESCRIPTION
Added search bar code to: node_modules/nodebb-theme-quickstart/templates/partials/topic-list-bar.tpl

The search bar is functional, but the back end logic for the search button is not yet added. These changes are purely UI changes. Will later be used to be able to search for topics. The ui is the same as the other search bars to maintain a consistent UI and is modeled after search bar code in: src/views/admin/manage/users.tpl